### PR TITLE
add vscode extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["bradlc.vscode-tailwindcss"]
+}


### PR DESCRIPTION
Hey 👋 I'm obviously biased, but I think it could be cool to add a VS Code `extensions.json` file, so that [Tailwind CSS IntelliSense](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss) is displayed as a recommended extension when opening the project.

When opening the project you get a little notification in the bottom right:

<img width="458" alt="Screenshot 2019-05-17 at 00 02 50" src="https://user-images.githubusercontent.com/2615508/57892688-c67b1400-7837-11e9-8852-23d94b5d4015.png">

After clicking on "Show Recommendations":

<img width="313" alt="Screenshot 2019-05-17 at 00 03 45" src="https://user-images.githubusercontent.com/2615508/57892698-cc70f500-7837-11e9-9a08-ec87dc73b00e.png">

Totally understand if you don’t want to add this though!