### PR TITLE
use browser-sync instead of live-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,19 +1,19 @@
 {
   "scripts": {
-    "serve": "cross-env NODE_ENV=development concurrently \"postcss public/tailwind.css -o public/build/tailwind.css --watch\"  \"live-server ./public\"",
+    "dev": "cross-env NODE_ENV=development concurrently \"postcss public/tailwind.css -o public/build/tailwind.css --watch\"  \"browser-sync start -s 'public' --files 'public' --open --no-notify\"",
     "development": "cross-env NODE_ENV=development postcss public/tailwind.css -o public/build/tailwind.css",
     "production": "cross-env NODE_ENV=production postcss public/tailwind.css -o public/build/tailwind.css"
   },
   "dependencies": {
-    "autoprefixer": "^9.5.1",
-    "tailwindcss": "^1.0"
+    "autoprefixer": "^9.6.0",
+    "tailwindcss": "^1.0.4"
   },
   "devDependencies": {
     "@fullhuman/postcss-purgecss": "^1.2.0",
+    "browser-sync": "^2.26.7",
     "concurrently": "^4.1.0",
     "cross-env": "^5.2.0",
     "cssnano": "^4.1.10",
-    "live-server": "^1.2.1",
     "postcss-cli": "^6.1.2"
   }
 }


### PR DESCRIPTION
browser-sync gives much better dev experience than live-server as you're able to play around with Tailwind and have updates on multiple devices and browsers without manually refreshing

