### PR TITLE
Add run on Repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm run serve"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A simple starter project for playing around with Tailwind in a proper PostCSS environment.
 
+[![Run on Repl.it](https://repl.it/badge/github/tailwindcss/playground)](https://repl.it/github/tailwindcss/playground)
+
 To get started:
 
 1. Clone the repository:


### PR DESCRIPTION
This pull request adds a `.replit` file and a button to the `README`. Clicking the button will instantly setup a dev environment in the cloud with a run button you can click to quickly start experimenting with Tailwind.css. I think that this can significantly improve a lot of peoples' workflows.

[This](https://repl.it/@Kognise/playground-1) is my copy of the playground.