### PR TITLE
remove 'run' from yarn command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To build an optimized version of your CSS, simply run:
 npm run production
 
 # Using Yarn
-yarn run production
+yarn production
 ```
 
 After that's done, check out `./public/build/tailwind.css` to see the optimized output.

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ To get started:
    # Using npm
    npm run serve
 
-    # Using Yarn
-    yarn serve
-    ```
+   # Using Yarn
+   yarn serve
+   ```
 
    Now you should be able to see the project running at localhost:8080.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To get started:
     npm run serve
 
     # Using Yarn
-    yarn run serve
+    yarn serve
     ```
 
     Now you should be able to see the project running at localhost:8080.


### PR DESCRIPTION
It’s also possible to leave out ```run``` in this command, each script can be executed with its name

For example ```yarn serve```, running this command will do the same as ```yarn run serve```. 

**The documentation further says**
```
Note that built-in cli commands will have preference over your scripts, so you shouldn’t always rely on this shortcut in other scripts
```